### PR TITLE
Stop video event

### DIFF
--- a/RCTYouTube.m
+++ b/RCTYouTube.m
@@ -36,9 +36,23 @@
         _isPlaying = NO;
         
         self.delegate = self;
+
+        [[NSNotificationCenter defaultCenter] addObserver:self
+                                                 selector:@selector(handleWhenDoneButtonClick:)
+                                                     name:UIWindowDidBecomeHiddenNotification
+                                                   object:self.webView.window];
     }
     
     return self;
+}
+
+- (void) handleWhenDoneButtonClick:(NSNotification *) notification {
+    NSString *playerState = @"done";
+    [_eventDispatcher sendInputEventWithName:@"youtubeVideoChangeState"
+                                        body:@{
+                                               @"state": playerState,
+                                               @"target": self.reactTag
+                                               }];
 }
 
 - (void)layoutSubviews {

--- a/YouTube.ios.js
+++ b/YouTube.ios.js
@@ -5,7 +5,7 @@
 
 'use strict';
 
-import { Component, PropTypes } from 'react';
+import React, { Component, PropTypes } from 'react';
 import ReactNative, {
   View,
   StyleSheet,


### PR DESCRIPTION
Dear @paramaggarwal and @Mokto, I'd would like your input on this:

When clicking on the "done" button, there is no change in state.
I am following this proposition - (https://github.com/youtube/youtube-ios-player-helper/issues/149)
to detect when the WebView disappears.

To differentiate between the `ended` state and this event, I've added a `done` state.

It feels a bit hackish, though, I would be happy to know if there's a nicer way to do it.
Thanks!
