### PR TITLE
fix README.  Move last part of iOS installation back under iOS section

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,14 @@ this.refs.youtubePlayer.seekTo(20);
 
 `$ add YTPlayerView-iframe-player.html from Assets to your xcode project`
 
+##### OPTIONAL : Activated sound when phone is on vibrate mode
+
+Open AppDelegate.m and add :
+
+* `#import <AVFoundation/AVFoundation.h>`
+
+* `[[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryPlayback error: nil];` in your didFinishLaunchingWithOptions method
+
 ##### Android : rnpm is not working yet !!
 
 In node_module :
@@ -102,14 +110,6 @@ import com.inprogress.reactnativeyoutube.ReactNativeYouTube;
       );
     }
  ```
-
-##### OPTIONAL : Activated sound when phone is on vibrate mode
-
-Open AppDelegate.m and add :
-
-* `#import <AVFoundation/AVFoundation.h>`
-
-* `[[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryPlayback error: nil];` in your didFinishLaunchingWithOptions method
 
 ## Example
 Try the included `RCTYouTubeExample`:


### PR DESCRIPTION
After the Android installation instructions were added, the "Activated sound when phone is on vibrate mode" that refers to AppDelegate is listed under the Android area.  I figured it should be up under the iOS section since it is iOS specific.  
