### PR TITLE
Fix for “More than one plugin attempted to publish the same registration name `onError` when using RN 0.39

### DIFF
--- a/RCTYouTube/src/main/java/com/inprogress/reactnativeyoutube/YouTubeManager.java
+++ b/RCTYouTube/src/main/java/com/inprogress/reactnativeyoutube/YouTubeManager.java
@@ -51,13 +51,13 @@ public class YouTubeManager extends SimpleViewManager<YouTubeView> {
     Map getExportedCustomDirectEventTypeConstants() {
         return MapBuilder.of(
                 "error",
-                MapBuilder.of("registrationName", "onError"),
+                MapBuilder.of("registrationName", "onYoutubeVideoError"),
                 "ready",
-                MapBuilder.of("registrationName", "onReady"),
+                MapBuilder.of("registrationName", "onYoutubeVideoReady"),
                 "state",
-                MapBuilder.of("registrationName", "onChangeState"),
+                MapBuilder.of("registrationName", "onYoutubeVideoChangeState"),
                 "quality",
-                MapBuilder.of("registrationName", "onChangeQuality")
+                MapBuilder.of("registrationName", "onYoutubeVideoChangeQuality")
         );
     }
 


### PR DESCRIPTION
Hi, first of all, awesome library, keep up the good work!

This pull request fixes the 'More than one plugin attempted to publish the same registration name `onError` when using react-native 0.39.

![image](https://cloud.githubusercontent.com/assets/6184593/20965041/5fede1ee-bc74-11e6-887e-d91d84b0bdaa.png)


This also fixes the event handlers for Android. The handlers defined `YouTube.android.js` were never triggered because the event names in the .java file were different. By accident the handlers passed to the YouTube component were still called, but directly by the native-code. This caused the arguments to be wrong. This commit fixes that as well.