### PR TITLE
Fixed/added support for inline playback support on Android

### DIFF
--- a/RCTYouTube/src/main/java/com/inprogress/reactnativeyoutube/YouTubeManager.java
+++ b/RCTYouTube/src/main/java/com/inprogress/reactnativeyoutube/YouTubeManager.java
@@ -20,7 +20,7 @@ public class YouTubeManager extends SimpleViewManager<YouTubeView> {
 
     public static final String PROP_VIDEO_ID = "videoId";
     public static final String PROP_API_KEY = "apiKey";
-    public static final String PROP_INLINE = "playInline";
+    public static final String PROP_INLINE = "playsInline";
     public static final String PROP_SHOW_INFO = "showinfo";
     public static final String PROP_MODESTBRANDING = "modestbranding";
     public static final String PROP_CONTROLS = "controls";

--- a/RCTYouTube/src/main/java/com/inprogress/reactnativeyoutube/YouTubePlayerController.java
+++ b/RCTYouTube/src/main/java/com/inprogress/reactnativeyoutube/YouTubePlayerController.java
@@ -144,7 +144,7 @@ public class YouTubePlayerController implements
 
     @Override
     public void onLoaded(String s) {
-
+        mYouTubeView.didChangeToState("loaded");
     }
 
     @Override

--- a/RCTYouTube/src/main/java/com/inprogress/reactnativeyoutube/YouTubePlayerController.java
+++ b/RCTYouTube/src/main/java/com/inprogress/reactnativeyoutube/YouTubePlayerController.java
@@ -176,6 +176,7 @@ public class YouTubePlayerController implements
 
     @Override
     public void onFullscreen(boolean isFullscreen) {
+        mYouTubeView.didChangeToState(isFullscreen ? "fullscreenMode" : "windowMode");
 
         // When exiting full-screen mode and inline playback is not enabled
         // then pause the video playback.

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ this.refs.youtubePlayer.seekTo(20);
 * `videoID`: The YouTube video ID to play, can be changed to change the video playing.
 * `play`: Controls playback of video with `true`/`false`. Setting it as `true` in the beginning itself makes the video autoplay on loading.
 * `hidden`: Controls the `view.hidden` native property. For example, use this to hide player while it loads.
-* `playsInline`: Controls whether the video should play inline, or in full screen.
+* `playsInline`: Controls whether the video should play inline, or in full screen. Default `false`.
 * `rel`: Hides related videos at the end of the video. Default `false`.
 * `loop`: Loops the video. Default `false`.
 * `modestbranding`: This parameter lets you use a YouTube player that does not show a YouTube logo. Default `false`.

--- a/YouTube.android.js
+++ b/YouTube.android.js
@@ -102,7 +102,7 @@ export default class YouTube extends Component {
         nativeProps.playerParams.playerVars = {};
 
         if (this.props.playsInline) {
-          nativeProps.playerParams.playerVars.playsinline = 1;
+          nativeProps.playerParams.playerVars.playsInline = 1;
           delete nativeProps.playsInline;
         };
         if (this.props.modestbranding) {
@@ -127,13 +127,6 @@ export default class YouTube extends Component {
           delete nativeProps.rel;
         };
       };
-    } else {
-      /*
-       * For compatibility issues with an older version where setting both
-       * `playsInline` and `videoId` in quick succession would cause the video
-       * to sometimes not play.
-       */
-      delete nativeProps.playsInline;
     }
 
     return <RCTYouTube {... nativeProps} />;


### PR DESCRIPTION
The prop `playsInline` doesn't work on Android. After inspecting I found that it is removed entirely from the props in `YouYube.android.js` (at the bottom). After further investigation I found that inline playback support is working very poorly. This pull requests adds proper inline playback handling for Android. It addresses the following issues:

- fix full-screen mode always started on load when play is false
- cue video when play is false so you can tap it to start the video
- start full-screen mode when video starts playing and inline is not enabled
- exit full-screen mode when video is ended and inline is enabled
- stop video from playing when exiting full-screen and inline is not enabled
- pause video playback when videoId prop is reset
- fix, don't start playback of video when videoId is changed but play is false
- start full-screen when setting play to true and inline is not enabled
- emit 'loaded' event when video has loaded
- emit 'fullscreenMode' and 'windowMode' events when entering/leaving fullscreen


This should fix the following error (which I was experiencing as well): #82  

Also, I noticed that because of the full-screen mode it often showed the dreaded "YouTube video playback stopped due to unauthorized overlay on top of player" bug. This is also fixed now, so should very likely fix #83 as well.

Example of inline video playback on Android:

![video](https://cloud.githubusercontent.com/assets/6184593/20983105/773d87e0-bcbb-11e6-8bba-9e35caaf77dc.gif)


Let me know if I can do anything to speed up the process of getting this accepted.

cheers, Hein

