### PR TITLE
Added support for the `fs` prop in order to hide the full-screen button

### DIFF
--- a/RCTYouTube/src/main/java/com/inprogress/reactnativeyoutube/YouTubeManager.java
+++ b/RCTYouTube/src/main/java/com/inprogress/reactnativeyoutube/YouTubeManager.java
@@ -28,6 +28,7 @@ public class YouTubeManager extends SimpleViewManager<YouTubeView> {
     public static final String PROP_HIDDEN = "hidden";
     public static final String PROP_REL = "rel";
     public static final String PROP_LOOP = "loop";
+    public static final String PROP_FULLSCREEN = "fs";
 
 
     public YouTubeManager() {
@@ -136,5 +137,10 @@ public class YouTubeManager extends SimpleViewManager<YouTubeView> {
         view.setShowInfo(param);
     }
 
-
+    @ReactProp(name = PROP_FULLSCREEN)
+    public void setPropFullscreen(
+            YouTubeView view, @Nullable Boolean param) {
+        Log.e(PROP_FULLSCREEN,""+param);
+        view.setFullscreen(param);
+    }
 }

--- a/RCTYouTube/src/main/java/com/inprogress/reactnativeyoutube/YouTubeManager.java
+++ b/RCTYouTube/src/main/java/com/inprogress/reactnativeyoutube/YouTubeManager.java
@@ -140,7 +140,7 @@ public class YouTubeManager extends SimpleViewManager<YouTubeView> {
     @ReactProp(name = PROP_FULLSCREEN)
     public void setPropFullscreen(
             YouTubeView view, @Nullable Boolean param) {
-        Log.e(PROP_FULLSCREEN,""+param);
+        //Log.e(PROP_FULLSCREEN,""+param);
         view.setFullscreen(param);
     }
 }

--- a/RCTYouTube/src/main/java/com/inprogress/reactnativeyoutube/YouTubePlayerController.java
+++ b/RCTYouTube/src/main/java/com/inprogress/reactnativeyoutube/YouTubePlayerController.java
@@ -28,6 +28,7 @@ public class YouTubePlayerController implements
     private boolean showInfo = true;
     private boolean loop = false;
     private boolean playInline = false;
+    private boolean fullscreen = true;
 
 
     public YouTubePlayerController(final Context mContext, YouTubeView youTubeView) {
@@ -41,6 +42,10 @@ public class YouTubePlayerController implements
             mYouTubePlayer = youTubePlayer;
             mYouTubePlayer.setPlayerStateChangeListener(this);
             mYouTubePlayer.setPlaybackEventListener(this);
+
+            // Update config
+            mYouTubePlayer.setShowFullscreenButton(fullscreen);
+
             mYouTubePlayer.setFullscreen(true);
             updateControls();
             mYouTubeView.playerViewDidBecomeReady();
@@ -153,6 +158,15 @@ public class YouTubePlayerController implements
         mYouTubeView.receivedError(errorReason.toString());
     }
 
+    @Override
+    public void onFullscreen(boolean isFullscreen) {
+
+        // When exiting full-screen mode and inline playback is not enabled
+        // then pause the video playback.
+        if (!isPlayInline() && !isFullscreen) {
+            mYouTubePlayer.pause();
+        }
+    }
 
     public void seekTo(int second) {
         if (isLoaded()) {
@@ -220,6 +234,13 @@ public class YouTubePlayerController implements
         }
     }
 
+    public void setFullscreen(boolean fullscreen) {
+        this.fullscreen = fullscreen;
+        if (isLoaded()) {
+            mYouTubePlayer.setShowFullscreenButton(fullscreen);
+        }
+    }
+
     //TODO
     public void setHidden(boolean hidden) {
         this.hidden = hidden;
@@ -278,4 +299,7 @@ public class YouTubePlayerController implements
         return playInline;
     }
 
+    public boolean isFullscreen() {
+        return fullscreen;
+    }
 }

--- a/RCTYouTube/src/main/java/com/inprogress/reactnativeyoutube/YouTubeView.java
+++ b/RCTYouTube/src/main/java/com/inprogress/reactnativeyoutube/YouTubeView.java
@@ -139,4 +139,8 @@ public class YouTubeView extends RelativeLayout {
     public void setRelated(Boolean related) {
         youtubeController.setRelated(related);
     }
+
+    public void setFullscreen(Boolean bool) {
+        youtubeController.setFullscreen(bool);
+    }
 }

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ this.refs.youtubePlayer.seekTo(20);
 * `play`: Controls playback of video with `true`/`false`. Setting it as `true` in the beginning itself makes the video autoplay on loading.
 * `hidden`: Controls the `view.hidden` native property. For example, use this to hide player while it loads.
 * `playsInline`: Controls whether the video should play inline, or in full screen.
+* `fs`: Controls whether the full screen button is shown. Default `true`.
 * `rel`: Hides related videos at the end of the video. Default `false`.
 * `loop`: Loops the video. Default `false`.
 * `modestbranding`: This parameter lets you use a YouTube player that does not show a YouTube logo. Default `false`.

--- a/YouTube.android.js
+++ b/YouTube.android.js
@@ -35,6 +35,7 @@ export default class YouTube extends Component {
     origin: PropTypes.string,
     play: PropTypes.bool,
     rel: PropTypes.bool,
+    fs: PropTypes.bool,
     hidden: PropTypes.bool,
     onReady: PropTypes.func,
     onChangeState: PropTypes.func,
@@ -125,6 +126,10 @@ export default class YouTube extends Component {
         if (this.props.rel!==undefined) {
           nativeProps.playerParams.playerVars.rel = this.props.rel ? 1 : 0;
           delete nativeProps.rel;
+        };
+        if (this.props.fs!==undefined) {
+          nativeProps.playerParams.playerVars.fs = this.props.fs ? 1 : 0;
+          delete nativeProps.fs;
         };
       };
     } else {

--- a/YouTube.ios.js
+++ b/YouTube.ios.js
@@ -33,6 +33,7 @@ export default class YouTube extends Component {
     onChangeQuality: PropTypes.func,
     onError: PropTypes.func,
     loop: PropTypes.bool,
+    fs: PropTypes.bool
   };
 
   static defaultProps = {
@@ -115,6 +116,10 @@ export default class YouTube extends Component {
         if (this.props.rel!==undefined) {
           nativeProps.playerParams.playerVars.rel = this.props.rel ? 1 : 0;
           delete nativeProps.rel;
+        };
+        if (this.props.fs!==undefined) {
+          nativeProps.playerParams.playerVars.fs = this.props.fs ? 1 : 0;
+          delete nativeProps.fs;
         };
       };
     } else {


### PR DESCRIPTION
This pull requests adds support for the `fs` prop. By default the fullscreen button is shown. This prop can be used to disable this button. Works on both Android and iOS.