### PR TITLE
Bugfix/android portrait mode

### DIFF
--- a/android/src/main/java/com/inprogress/reactnativeyoutube/YouTubeView.java
+++ b/android/src/main/java/com/inprogress/reactnativeyoutube/YouTubeView.java
@@ -4,6 +4,7 @@ import android.app.Activity;
 import android.app.FragmentManager;
 import android.app.FragmentTransaction;
 import android.content.Context;
+import android.content.pm.ActivityInfo;
 import android.widget.RelativeLayout;
 
 import com.facebook.react.bridge.Arguments;

--- a/android/src/main/java/com/inprogress/reactnativeyoutube/YouTubeView.java
+++ b/android/src/main/java/com/inprogress/reactnativeyoutube/YouTubeView.java
@@ -18,6 +18,8 @@ import android.util.Log;
 
 public class YouTubeView extends RelativeLayout {
 
+    public static final String TAG = "YouTubeView";
+
     YouTubePlayerController youtubeController;
     private YouTubePlayerFragment youTubePlayerFragment;
     public static String youtube_key;
@@ -50,7 +52,7 @@ public class YouTubeView extends RelativeLayout {
             ft.remove(youTubePlayerFragment);
             ft.commit();
         } catch (Exception e) {
-
+            Log.e(TAG, "Exception thrown in onDetachedFromWindow method...", e);
         }
         getReactContext()
                 .getCurrentActivity()

--- a/android/src/main/java/com/inprogress/reactnativeyoutube/YouTubeView.java
+++ b/android/src/main/java/com/inprogress/reactnativeyoutube/YouTubeView.java
@@ -13,6 +13,8 @@ import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.uimanager.events.RCTEventEmitter;
 import com.google.android.youtube.player.YouTubePlayerFragment;
 
+import android.util.Log;
+
 
 public class YouTubeView extends RelativeLayout {
 
@@ -48,7 +50,11 @@ public class YouTubeView extends RelativeLayout {
             ft.remove(youTubePlayerFragment);
             ft.commit();
         } catch (Exception e) {
+
         }
+        getReactContext()
+                .getCurrentActivity()
+                .setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);
         super.onDetachedFromWindow();
     }
 


### PR DESCRIPTION
A fix for the bug where after exiting the fullscreen mode of the video, the screen orientation would still be left in landscape mode.

The app that I am working on, is always in Portrait mode, so this fix makes sense for us. If you would like to use the sensor information or some other pre-defined rules on which orientation should be set when exiting the fullscreen, then a more complicated solution should be found.

This fixes #114