### PR TITLE
iOS 10 playsInline false fix

### DIFF
--- a/YTPlayerView/YTPlayerView.m
+++ b/YTPlayerView/YTPlayerView.m
@@ -711,7 +711,11 @@ NSString static *const kYTPlayerStaticProxyRegexPattern = @"^https://content.goo
   NSString *embedHTML = [NSString stringWithFormat:embedHTMLTemplate, playerVarsJsonString];
   [self.webView loadHTMLString:embedHTML baseURL: self.originURL];
   [self.webView setDelegate:self];
-  self.webView.allowsInlineMediaPlayback = YES;
+  
+  //This is needed because due to iOS 10, videos do not play full screen if allowsInlineMediaPLayback is set to YES; 
+  BOOL shouldPlayInline = [[playerParams objectForKey: @"playerVars"] objectForKey:@"playsinline"];
+  self.webView.allowsInlineMediaPlayback = shouldPlayInline;
+  
   self.webView.mediaPlaybackRequiresUserAction = NO;
   return YES;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-youtube",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "A <YouTube/> component for React Native.",
   "main": "main.js",
   "scripts": {


### PR DESCRIPTION
Fixed a bug that prevents videos from being auto played in full screen if playsInline is set to false so that video is displayed. See #136 