### PR TITLE
Add CocoaPods podspec

### DIFF
--- a/react-native-youtube.podspec
+++ b/react-native-youtube.podspec
@@ -1,0 +1,20 @@
+require 'json'
+package_json = JSON.parse(File.read('package.json'))
+
+Pod::Spec.new do |s|
+
+  s.name           = package_json["name"]
+  s.version        = package_json["version"]
+  s.summary        = package_json["description"]
+  s.homepage       = package_json["homepage"]
+  s.license        = package_json["license"]
+  s.author         = { package_json["author"] => package_json["author"] }
+  s.platform       = :ios, "7.0"
+  s.source         = { :git => package_json["repository"]["url"].gsub(/(http.*)/).first, :tag => "v#{s.version}" }
+  s.source_files   = 'RCTYouTube*.{h,m}'
+  s.preserve_paths = '*.js'
+
+  s.dependency 'React'
+  s.dependency 'youtube-ios-player-helper'
+
+end


### PR DESCRIPTION
Hi there,

I added a podspec so this lib can be used on iOS apps that use CocoaPods to manage React Native.

Example usage in Podfile
```
[...]
pod 'react-native-youtube', :path => '../node_modules/react-native-youtube'
```

Let me know what you think.