### PR TITLE
Change from BackAndroid to BackHandler

### DIFF
--- a/YouTube.android.js
+++ b/YouTube.android.js
@@ -10,7 +10,7 @@ import ReactNative, {
   requireNativeComponent,
   UIManager,
   NativeModules,
-  BackAndroid,
+  BackHandler,
 } from 'react-native';
 
 const RCTYouTube = requireNativeComponent('ReactYouTube', YouTube, {
@@ -59,7 +59,7 @@ export default class YouTube extends React.Component {
   }
 
   componentWillMount() {
-    BackAndroid.addEventListener('hardwareBackPress', this._backAndroidHandler);
+    BackHandler.addEventListener('hardwareBackPress', this._backAndroidHandler);
   }
 
   componentWillReceiveProps(nextProps) {
@@ -70,7 +70,7 @@ export default class YouTube extends React.Component {
   }
 
   componentWillUnmount() {
-    BackAndroid.removeEventListener('hardwareBackPress', this._backAndroidHandler);
+    BackHandler.removeEventListener('hardwareBackPress', this._backAndroidHandler);
   }
 
   _backAndroidHandler = () => {

--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
   },
   "homepage": "https://github.com/inProgress-team/react-native-youtube#readme",
   "peerDependencies": {
-    "react": ">=15.3.2",
-    "react-native": ">=0.37"
+    "react": ">=16.0.0-alpha.6",
+    "react-native": ">=0.44"
   },
   "rnpm": {
     "android": {


### PR DESCRIPTION
The BackAndroid module has been deprecated in React Native 0.44 and
replaced with a new module called BackHandler.

The API for both modules is the same so this switches the modules to
provide compatibility going forwards.