### PR TITLE
fix #162

### DIFF
--- a/YouTube.android.js
+++ b/YouTube.android.js
@@ -10,8 +10,11 @@ import ReactNative, {
   requireNativeComponent,
   UIManager,
   NativeModules,
-  BackAndroid,
+  BackAndroid as DeprecatedBackAndroid,
+  BackHandler,
 } from 'react-native';
+
+const BackAndroid = BackHandler || DeprecatedBackAndroid;
 
 const RCTYouTube = requireNativeComponent('ReactYouTube', YouTube, {
   nativeOnly: {

--- a/YouTube.android.js
+++ b/YouTube.android.js
@@ -10,11 +10,11 @@ import ReactNative, {
   requireNativeComponent,
   UIManager,
   NativeModules,
-  BackAndroid as DeprecatedBackAndroid,
-  BackHandler,
+  BackAndroid,
+  BackHandler as BackHandlerModule,
 } from 'react-native';
 
-const BackAndroid = BackHandler || DeprecatedBackAndroid;
+const BackHandler = BackHandlerModule || BackAndroid;
 
 const RCTYouTube = requireNativeComponent('ReactYouTube', YouTube, {
   nativeOnly: {
@@ -62,7 +62,7 @@ export default class YouTube extends React.Component {
   }
 
   componentWillMount() {
-    BackAndroid.addEventListener('hardwareBackPress', this._backAndroidHandler);
+    BackHandler.addEventListener('hardwareBackPress', this._backPress);
   }
 
   componentWillReceiveProps(nextProps) {
@@ -73,10 +73,10 @@ export default class YouTube extends React.Component {
   }
 
   componentWillUnmount() {
-    BackAndroid.removeEventListener('hardwareBackPress', this._backAndroidHandler);
+    BackHandler.removeEventListener('hardwareBackPress', this._backPress);
   }
 
-  _backAndroidHandler = () => {
+  _backPress = () => {
     if (this.state.fullscreen) {
       this.setState({ fullscreen: false })
       return true


### PR DESCRIPTION
If we can't import BackHandler, BackHandler will be undefined and we will use BackAndroid.

```
import {
  ...
  BackAndroid as DeprecatedBackAndroid,
  BackHandler
} from "react-native";

const BackAndroid = BackHandler || DeprecatedBackAndroid;
```