### PR TITLE
Add Standalone Player

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,8 @@ DerivedData
 *.hmap
 *.ipa
 *.xcuserstate
+.DS_Store
+.vscode/
 
 # CocoaPods
 #

--- a/YouTubeStandalone.android.js
+++ b/YouTubeStandalone.android.js
@@ -1,0 +1,6 @@
+import React from "react";
+import { NativeModules } from "react-native";
+
+const { YouTubeModule } = NativeModules;
+
+module.exports = YouTubeModule;

--- a/android/src/main/java/com/inprogress/reactnativeyoutube/YouTubeModule.java
+++ b/android/src/main/java/com/inprogress/reactnativeyoutube/YouTubeModule.java
@@ -9,7 +9,6 @@ import com.facebook.react.uimanager.NativeViewHierarchyManager;
 import com.facebook.react.uimanager.UIBlock;
 import com.facebook.react.uimanager.UIManagerModule;
 
-// JT
 import com.facebook.react.bridge.BaseActivityEventListener;
 import com.facebook.react.bridge.ActivityEventListener;
 import android.app.Activity;
@@ -25,7 +24,6 @@ public class YouTubeModule extends ReactContextBaseJavaModule {
 
     private ReactApplicationContext mReactContext;
 
-    // JT
     private static final int REQ_START_STANDALONE_PLAYER = 1;
     private static final int REQ_RESOLVE_SERVICE_MISSING = 2;
     private static final String E_FAILED_TO_SHOW_PLAYER = "E_FAILED_TO_SHOW_PLAYER";
@@ -66,7 +64,6 @@ public class YouTubeModule extends ReactContextBaseJavaModule {
         super(reactContext);
         mReactContext = reactContext;
 
-        // JT
         mReactContext.addActivityEventListener(mActivityEventListener);
     }
 
@@ -109,7 +106,6 @@ public class YouTubeModule extends ReactContextBaseJavaModule {
         }
     }
 
-    // JT
     @ReactMethod
     public void playVideo(final String apiKey, final String video_id, final boolean autoplay, final boolean lightboxMode, final int startTimeMillis, final Promise promise) {
       Activity currentActivity = getCurrentActivity();

--- a/android/src/main/java/com/inprogress/reactnativeyoutube/YouTubeModule.java
+++ b/android/src/main/java/com/inprogress/reactnativeyoutube/YouTubeModule.java
@@ -9,14 +9,65 @@ import com.facebook.react.uimanager.NativeViewHierarchyManager;
 import com.facebook.react.uimanager.UIBlock;
 import com.facebook.react.uimanager.UIManagerModule;
 
+// JT
+import com.facebook.react.bridge.BaseActivityEventListener;
+import com.facebook.react.bridge.ActivityEventListener;
+import android.app.Activity;
+import android.content.Intent;
+import android.widget.Toast;
+import android.content.pm.ResolveInfo;
+import com.google.android.youtube.player.YouTubeInitializationResult;
+import com.google.android.youtube.player.YouTubeStandalonePlayer;
+
+import java.util.List;
 
 public class YouTubeModule extends ReactContextBaseJavaModule {
 
     private ReactApplicationContext mReactContext;
 
+    // JT
+    private static final int REQ_START_STANDALONE_PLAYER = 1;
+    private static final int REQ_RESOLVE_SERVICE_MISSING = 2;
+    private static final String E_FAILED_TO_SHOW_PLAYER = "E_FAILED_TO_SHOW_PLAYER";
+    private static final String E_PLAYER_ERROR = "E_PLAYER_ERROR";
+    private static final String E_ACTIVITY_DOES_NOT_EXIST = "E_ACTIVITY_DOES_NOT_EXIST";
+
+    private Promise mPickerPromise;
+
+    private final ActivityEventListener mActivityEventListener = new BaseActivityEventListener() {
+
+      @Override
+      public void onActivityResult(Activity activity, int requestCode, int resultCode, Intent intent) {
+        if (requestCode == REQ_START_STANDALONE_PLAYER) {
+          if (mPickerPromise != null) {
+            if (resultCode != Activity.RESULT_OK) {
+              YouTubeInitializationResult errorReason =
+                  YouTubeStandalonePlayer.getReturnedInitializationResult(intent);
+              if (errorReason.isUserRecoverableError()) {
+                  errorReason.getErrorDialog(activity, 0).show();
+                  mPickerPromise.reject(E_PLAYER_ERROR);
+              } else {
+                  String errorMessage =
+                      String.format("There was an error initializing the YouTubePlayer (%1$s)", errorReason.toString());
+                  Toast.makeText(activity, errorMessage, Toast.LENGTH_LONG).show();
+                  mPickerPromise.reject(E_PLAYER_ERROR, errorMessage);
+              }
+            } else {
+              mPickerPromise.resolve(null);
+            }
+
+            mPickerPromise = null;
+          }
+        }
+      }
+    };
+
     public YouTubeModule(ReactApplicationContext reactContext) {
         super(reactContext);
         mReactContext = reactContext;
+
+        // JT
+        mReactContext.addActivityEventListener(mActivityEventListener);
     }
 
     @Override
@@ -56,5 +107,44 @@ public class YouTubeModule extends ReactContextBaseJavaModule {
         } catch (IllegalViewOperationException e) {
             promise.reject("YouTubeModule.currentTime() failed", e);
         }
+    }
+
+    // JT
+    @ReactMethod
+    public void playVideo(final String apiKey, final String video_id, final boolean autoplay, final boolean lightboxMode, final int startTimeMillis, final Promise promise) {
+      Activity currentActivity = getCurrentActivity();
+
+      if (currentActivity == null) {
+        promise.reject(E_ACTIVITY_DOES_NOT_EXIST, "Activity doesn't exist");
+        return;
+      }
+
+      // Store the promise to resolve/reject when picker returns data
+      mPickerPromise = promise;
+
+      try {
+        // final Intent galleryIntent = new Intent(Intent.ACTION_PICK);
+        final Intent intent = YouTubeStandalonePlayer.createVideoIntent(
+          currentActivity, apiKey, video_id, startTimeMillis, autoplay, lightboxMode);
+
+        if (intent != null) {
+          if (canResolveIntent(intent)) {
+            currentActivity.startActivityForResult(intent, REQ_START_STANDALONE_PLAYER);
+          } else {
+            // Could not resolve the intent - must need to install or update the YouTube API service.
+            YouTubeInitializationResult.SERVICE_MISSING
+                .getErrorDialog(currentActivity, REQ_RESOLVE_SERVICE_MISSING).show();
+          }
+        }
+
+      } catch (Exception e) {
+        mPickerPromise.reject(E_FAILED_TO_SHOW_PLAYER, e);
+        mPickerPromise = null;
+      }
+    }
+
+    private boolean canResolveIntent(Intent intent) {
+      List<ResolveInfo> resolveInfo = mReactContext.getPackageManager().queryIntentActivities(intent, 0);
+      return resolveInfo != null && !resolveInfo.isEmpty();
     }
 }

--- a/android/src/main/java/com/inprogress/reactnativeyoutube/YouTubeModule.java
+++ b/android/src/main/java/com/inprogress/reactnativeyoutube/YouTubeModule.java
@@ -13,7 +13,6 @@ import com.facebook.react.bridge.BaseActivityEventListener;
 import com.facebook.react.bridge.ActivityEventListener;
 import android.app.Activity;
 import android.content.Intent;
-import android.widget.Toast;
 import android.content.pm.ResolveInfo;
 import com.google.android.youtube.player.YouTubeInitializationResult;
 import com.google.android.youtube.player.YouTubeStandalonePlayer;
@@ -47,7 +46,6 @@ public class YouTubeModule extends ReactContextBaseJavaModule {
               } else {
                   String errorMessage =
                       String.format("There was an error initializing the YouTubePlayer (%1$s)", errorReason.toString());
-                  Toast.makeText(activity, errorMessage, Toast.LENGTH_LONG).show();
                   mPickerPromise.reject(E_PLAYER_ERROR, errorMessage);
               }
             } else {

--- a/android/src/main/java/com/inprogress/reactnativeyoutube/YouTubeModule.java
+++ b/android/src/main/java/com/inprogress/reactnativeyoutube/YouTubeModule.java
@@ -117,7 +117,6 @@ public class YouTubeModule extends ReactContextBaseJavaModule {
       mPickerPromise = promise;
 
       try {
-        // final Intent galleryIntent = new Intent(Intent.ACTION_PICK);
         final Intent intent = YouTubeStandalonePlayer.createVideoIntent(
           currentActivity, apiKey, video_id, startTimeMillis, autoplay, lightboxMode);
 

--- a/example/RCTYouTubeExample.js
+++ b/example/RCTYouTubeExample.js
@@ -10,7 +10,7 @@ import {
   Dimensions,
   Platform,
 } from 'react-native';
-import YouTube from 'react-native-youtube';
+import {YouTube, YouTubeStandalone} from 'react-native-youtube';
 
 class RCTYouTubeExample extends React.Component {
   state = {
@@ -64,6 +64,28 @@ class RCTYouTubeExample extends React.Component {
             ? e => this.setState({ duration: e.duration, currentTime: e.currentTime })
             : undefined}
         />
+
+        {/* Standalone Player */}
+        {Platform.OS === 'android' &&
+          <View style={styles.buttonGroup}>
+            <TouchableOpacity
+              style={styles.button}
+              onPress={() =>
+                // You must have an apiKey for the player to load in Android
+                YouTubeStandalone.playVideo(
+                  "",
+                  "KVZ-P-ZI6W4",
+                  false,
+                  false,
+                  0
+                )
+                  .then(() => console.log("Player Finished"))
+                  .catch(errorMessage => this.setState({ error: errorMessage }))}
+            >
+              <Text style={styles.buttonText}>Standalone Player</Text>
+            </TouchableOpacity>
+          </View>
+        }
 
         {/* Playing / Looping */}
         <View style={styles.buttonGroup}>

--- a/main.js
+++ b/main.js
@@ -1,3 +1,4 @@
-import YouTube from './YouTube';
+import YouTube from "./YouTube";
+import YouTubeStandalone from "./YouTubeStandalone.android";
 
-module.exports = YouTube;
+module.exports = { YouTube, YouTubeStandalone };


### PR DESCRIPTION
I added the possibility to run a YouTube player as a standalone player. It uses the same native module but it exports as YouTubeStandalone to be used in React . Needless to say, it only works for Android. 
The player can be started just using `YouTubeStandalone.playVideo("apiKey", "videoId", autoplay, lightbox, startTimeMillis)`

It's missing a few extra functionalities from the standalone player, but I will add them later, like using a playlist or a list of videos

Let me now what you guys think