### PR TITLE
Check if savedinstancestate has already occurred.

### DIFF
--- a/android/src/main/java/com/inprogress/reactnativeyoutube/YouTubeView.java
+++ b/android/src/main/java/com/inprogress/reactnativeyoutube/YouTubeView.java
@@ -1,6 +1,8 @@
 package com.inprogress.reactnativeyoutube;
 
 import android.app.FragmentManager;
+import android.os.Parcelable;
+import android.support.annotation.Nullable;
 import android.util.Log;
 import android.widget.FrameLayout;
 
@@ -17,6 +19,7 @@ public class YouTubeView extends FrameLayout {
 
     private YouTubePlayerController mYoutubeController;
     private YouTubePlayerFragment mYouTubePlayerFragment;
+    private boolean mHasSavedInstance = false;
 
     public YouTubeView(ReactContext context) {
         super(context);
@@ -33,10 +36,20 @@ public class YouTubeView extends FrameLayout {
         mYoutubeController = new YouTubePlayerController(this);
     }
 
+    @Nullable
+    @Override
+    protected Parcelable onSaveInstanceState() {
+        mHasSavedInstance = true;
+        return super.onSaveInstanceState();
+    }
+
     @Override
     protected void onAttachedToWindow() {
-        FragmentManager fragmentManager = getReactContext().getCurrentActivity().getFragmentManager();
-        fragmentManager.beginTransaction().add(getId(), mYouTubePlayerFragment).commit();
+        if (!mHasSavedInstance) {
+            FragmentManager fragmentManager = getReactContext().getCurrentActivity().getFragmentManager();
+            fragmentManager.beginTransaction().add(getId(), mYouTubePlayerFragment).commit();
+        }
+        super.onAttachedToWindow();
     }
 
     @Override
@@ -47,6 +60,7 @@ public class YouTubeView extends FrameLayout {
                 fragmentManager.beginTransaction().remove(mYouTubePlayerFragment).commit();
             }
         }
+        super.onDetachedFromWindow();
     }
 
     public void seekTo(int second) {


### PR DESCRIPTION
We cannot commit on fragment manager after the view has been removed. 

Fixes:

```
java.lang.IllegalStateException: Can not perform this action after onSaveInstanceState
	at android.app.FragmentManagerImpl.checkStateLoss(FragmentManager.java:1434)
	at android.app.FragmentManagerImpl.enqueueAction(FragmentManager.java:1452)
	at android.app.BackStackRecord.commitInternal(BackStackRecord.java:708)
	at android.app.BackStackRecord.commit(BackStackRecord.java:672)
	at com.inprogress.reactnativeyoutube.YouTubeView.onAttachedToWindow(YouTubeView.java:39)
	at android.view.View.dispatchAttachedToWindow(View.java:15509)
	at android.view.ViewGroup.dispatchAttachedToWindow(ViewGroup.java:2916)
	at android.view.ViewGroup.dispatchAttachedToWindow(ViewGroup.java:2923)
	at android.view.ViewGroup.dispatchAttachedToWindow(ViewGroup.java:2923)
	at android.view.ViewGroup.dispatchAttachedToWindow(ViewGroup.java:2923)
	at android.view.ViewGroup.dispatchAttachedToWindow(ViewGroup.java:2923)
	at android.view.ViewGroup.dispatchAttachedToWindow(ViewGroup.java:2923)
	at android.view.ViewGroup.dispatchAttachedToWindow(ViewGroup.java:2923)
	at android.view.ViewGroup.dispatchAttachedToWindow(ViewGroup.java:2923)
	at android.view.ViewGroup.addViewInner(ViewGroup.java:4456)
	at android.view.ViewGroup.addView(ViewGroup.java:4258)
	at android.view.ViewGroup.addView(ViewGroup.java:4198)
	at com.facebook.react.uimanager.ViewGroupManager.addView(ViewGroupManager.java:47)
	at com.facebook.react.uimanager.NativeViewHierarchyManager.manageChildren(NativeViewHierarchyManager.java:395)
	at com.facebook.react.uimanager.UIViewOperationQueue$ManageChildrenOperation.execute(UIViewOperationQueue.java:179)
	at com.facebook.react.uimanager.UIViewOperationQueue$1.run(UIViewOperationQueue.java:768)
	at com.facebook.react.uimanager.UIViewOperationQueue.flushPendingBatches(UIViewOperationQueue.java:824)
	at com.facebook.react.uimanager.UIViewOperationQueue.access$1600(UIViewOperationQueue.java:48)
	at com.facebook.react.uimanager.UIViewOperationQueue$2.runGuarded(UIViewOperationQueue.java:796)
	at com.facebook.react.bridge.GuardedRunnable.run(GuardedRunnable.java:21)
	at android.os.Handler.handleCallback(Handler.java:751)
	at android.os.Handler.dispatchMessage(Handler.java:95)
	at android.os.Looper.loop(Looper.java:154)
	at android.app.ActivityThread.main(ActivityThread.java:6121)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:889)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:779)
```