### PR TITLE
Update podspec to reflect the fact that we now embed YTPlayerView

### DIFF
--- a/react-native-youtube.podspec
+++ b/react-native-youtube.podspec
@@ -11,10 +11,9 @@ Pod::Spec.new do |s|
   s.author         = { package_json["author"] => package_json["author"] }
   s.platform       = :ios, "7.0"
   s.source         = { :git => package_json["repository"]["url"].gsub(/(http.*)/).first, :tag => "v#{s.version}" }
-  s.source_files   = 'RCTYouTube*.{h,m}'
+  s.source_files   = 'RCTYouTube*.{h,m}', 'YTPlayerView/YTPlayerView.{h,m}'
   s.preserve_paths = '*.js'
-
+  s.resources      = ['assets/YTPlayerView-iframe-player.html']
   s.dependency 'React'
-  s.dependency 'youtube-ios-player-helper'
 
 end


### PR DESCRIPTION
If you include react-native-youtube using your Podfile, i.e.:

```
pod 'react-native-youtube', :path => 'node_modules/react-native-youtube'
```

At runtime your project will fail to find the YTPlayerView-iframe-player.html. This is because we now embed YTPlayerView.{h,m}, which contains new logic for how it detects the YTPlayerView-iframe-player.html.

Thus, we need to update our .podspec file to include references both to our newly embedded YTPlayerView.{h,m} and our included YTPlayerView-iframe-player.html.