### PR TITLE
Fix crashing bug: java.lang.IllegalStateException: Activity has been destroyed 

### DIFF
--- a/android/src/main/java/com/inprogress/reactnativeyoutube/YouTubeView.java
+++ b/android/src/main/java/com/inprogress/reactnativeyoutube/YouTubeView.java
@@ -1,6 +1,7 @@
 package com.inprogress.reactnativeyoutube;
 
 import android.app.FragmentManager;
+import android.os.Build;
 import android.os.Parcelable;
 import android.support.annotation.Nullable;
 import android.util.Log;
@@ -56,8 +57,20 @@ public class YouTubeView extends FrameLayout {
     protected void onDetachedFromWindow() {
         if (getReactContext().getCurrentActivity() != null) {
             FragmentManager fragmentManager = getReactContext().getCurrentActivity().getFragmentManager();
+
+            // Code crashes with java.lang.IllegalStateException: Activity has been destroyed
+            // if our activity has been destroyed when this runs
             if (mYouTubePlayerFragment != null) {
-                fragmentManager.beginTransaction().remove(mYouTubePlayerFragment).commit();
+                boolean isDestroyed = false;
+
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+                    isDestroyed = getReactContext().getCurrentActivity().isDestroyed();
+                }
+
+                if (!isDestroyed) {
+                    // https://stackoverflow.com/a/34508430/61072
+                    fragmentManager.beginTransaction().remove(mYouTubePlayerFragment).commitAllowingStateLoss();
+                }
             }
         }
         super.onDetachedFromWindow();


### PR DESCRIPTION
There is a crashing bug when closing an activity with a ReactRootView that contains a YouTube component.

Specifically, this line:
https://github.com/inProgress-team/react-native-youtube/blob/master/android/src/main/java/com/inprogress/reactnativeyoutube/YouTubeView.java#L60

` fragmentManager.beginTransaction().remove(mYouTubePlayerFragment).commit();`

Triggers an exception if the activity has already been destroy.

We need to check to see if the activity has not yet been destroyed before using our fragmentManager.