### PR TITLE
Change type of variables related to time to float

### DIFF
--- a/RCTYouTubeManager.m
+++ b/RCTYouTubeManager.m
@@ -105,7 +105,7 @@ RCT_EXPORT_METHOD(currentTime:(nonnull NSNumber *)reactTag resolver:(RCTPromiseR
     [self.bridge.uiManager addUIBlock:^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, UIView *> *viewRegistry) {
         RCTYouTube *youtube = (RCTYouTube*)viewRegistry[reactTag];
         if ([youtube isKindOfClass:[RCTYouTube class]]) {
-            NSNumber *index = [NSNumber numberWithInt:[youtube currentTime]];
+            NSNumber *index = [NSNumber numberWithFloat:[youtube currentTime]];
             if (index) {
                 resolve(index);
             } else {

--- a/YouTube.android.js
+++ b/YouTube.android.js
@@ -129,7 +129,7 @@ export default class YouTube extends React.Component {
     UIManager.dispatchViewManagerCommand(
       ReactNative.findNodeHandle(this._nativeComponentRef),
       UIManager.ReactYouTube.Commands.seekTo,
-      [parseInt(seconds, 10)],
+      [parseFloat(seconds, 10)],
     );
   }
 

--- a/YouTube.ios.js
+++ b/YouTube.ios.js
@@ -107,7 +107,7 @@ export default class YouTube extends React.Component {
   };
 
   seekTo(seconds) {
-    NativeModules.YouTubeManager.seekTo(ReactNative.findNodeHandle(this), parseInt(seconds, 10));
+    NativeModules.YouTubeManager.seekTo(ReactNative.findNodeHandle(this), parseFloat(seconds, 10));
   }
 
   nextVideo() {

--- a/android/src/main/java/com/inprogress/reactnativeyoutube/YouTubeManager.java
+++ b/android/src/main/java/com/inprogress/reactnativeyoutube/YouTubeManager.java
@@ -88,11 +88,11 @@ public class YouTubeManager extends SimpleViewManager<YouTubeView> {
         );
     }
 
-    public int getCurrentTime(YouTubeView view) {
+    public float getCurrentTime(YouTubeView view) {
         return view.getCurrentTime();
     }
 
-    public int getDuration(YouTubeView view) {
+    public float getDuration(YouTubeView view) {
         return view.getDuration();
     }
 

--- a/android/src/main/java/com/inprogress/reactnativeyoutube/YouTubeManager.java
+++ b/android/src/main/java/com/inprogress/reactnativeyoutube/YouTubeManager.java
@@ -50,7 +50,7 @@ public class YouTubeManager extends SimpleViewManager<YouTubeView> {
         Assertions.assertNotNull(args);
         switch (commandType) {
             case COMMAND_SEEK_TO: {
-                view.seekTo(args.getInt(0));
+                view.seekTo((float)(args.getDouble(0)));
                 return;
             }
             case COMMAND_NEXT_VIDEO: {

--- a/android/src/main/java/com/inprogress/reactnativeyoutube/YouTubeModule.java
+++ b/android/src/main/java/com/inprogress/reactnativeyoutube/YouTubeModule.java
@@ -51,7 +51,7 @@ public class YouTubeModule extends ReactContextBaseJavaModule {
                 public void execute (NativeViewHierarchyManager nvhm) {
                     YouTubeView youTubeView = (YouTubeView) nvhm.resolveView(reactTag);
                     YouTubeManager youTubeManager = (YouTubeManager) nvhm.resolveViewManager(reactTag);
-                    int currentTime = youTubeManager.getCurrentTime(youTubeView);
+                    float currentTime = youTubeManager.getCurrentTime(youTubeView);
                     promise.resolve(currentTime);
                 }
             });
@@ -68,7 +68,7 @@ public class YouTubeModule extends ReactContextBaseJavaModule {
                 public void execute (NativeViewHierarchyManager nvhm) {
                     YouTubeView youTubeView = (YouTubeView) nvhm.resolveView(reactTag);
                     YouTubeManager youTubeManager = (YouTubeManager) nvhm.resolveViewManager(reactTag);
-                    int duration = youTubeManager.getDuration(youTubeView);
+                    float duration = youTubeManager.getDuration(youTubeView);
                     promise.resolve(duration);
                 }
             });

--- a/android/src/main/java/com/inprogress/reactnativeyoutube/YouTubePlayerController.java
+++ b/android/src/main/java/com/inprogress/reactnativeyoutube/YouTubePlayerController.java
@@ -158,15 +158,15 @@ public class YouTubePlayerController implements
     }
 
     public void seekTo(float second) {
-        if (isLoaded()) mYouTubePlayer.seekToMillis(second * 1000);
+        if (isLoaded()) mYouTubePlayer.seekToMillis((int)(second * 1000));
     }
 
     public float getCurrentTime() {
-      return mYouTubePlayer.getCurrentTimeMillis() / 1000.0;
+      return mYouTubePlayer.getCurrentTimeMillis() / 1000.f;
     }
 
     public float getDuration() {
-      return mYouTubePlayer.getDurationMillis() / 1000.0;
+      return mYouTubePlayer.getDurationMillis() / 1000.f;
     }
 
     public void nextVideo() {

--- a/android/src/main/java/com/inprogress/reactnativeyoutube/YouTubePlayerController.java
+++ b/android/src/main/java/com/inprogress/reactnativeyoutube/YouTubePlayerController.java
@@ -108,8 +108,8 @@ public class YouTubePlayerController implements
     }
 
     @Override
-    public void onSeekTo(int i) {
-        mYouTubeView.didChangeToSeeking(i);
+    public void onSeekTo(int newPositionMillis) {
+        mYouTubeView.didChangeToSeeking(newPositionMillis);
     }
 
     @Override
@@ -157,16 +157,16 @@ public class YouTubePlayerController implements
         mYouTubeView.receivedError(errorReason.toString());
     }
 
-    public void seekTo(int second) {
+    public void seekTo(float second) {
         if (isLoaded()) mYouTubePlayer.seekToMillis(second * 1000);
     }
 
-    public int getCurrentTime() {
-      return mYouTubePlayer.getCurrentTimeMillis() / 1000;
+    public float getCurrentTime() {
+      return mYouTubePlayer.getCurrentTimeMillis() / 1000.0;
     }
 
-    public int getDuration() {
-      return mYouTubePlayer.getDurationMillis() / 1000;
+    public float getDuration() {
+      return mYouTubePlayer.getDurationMillis() / 1000.0;
     }
 
     public void nextVideo() {

--- a/android/src/main/java/com/inprogress/reactnativeyoutube/YouTubeView.java
+++ b/android/src/main/java/com/inprogress/reactnativeyoutube/YouTubeView.java
@@ -73,15 +73,15 @@ public class YouTubeView extends FrameLayout {
         super.onDetachedFromWindow();
     }
 
-    public void seekTo(int second) {
+    public void seekTo(float second) {
         mYouTubeController.seekTo(second);
     }
 
-    public int getCurrentTime() {
+    public float getCurrentTime() {
         return mYouTubeController.getCurrentTime();
     }
 
-    public int getDuration() {
+    public float getDuration() {
         return mYouTubeController.getDuration();
     }
 
@@ -123,7 +123,7 @@ public class YouTubeView extends FrameLayout {
     public void didChangeToSeeking(int milliSeconds) {
         WritableMap event = Arguments.createMap();
         event.putString("state", "seeking");
-        event.putInt("currentTime", milliSeconds / 1000);
+        event.putDouble("currentTime", milliSeconds / 1000.0);
         event.putInt("target", getId());
         ReactContext reactContext = getReactContext();
         reactContext.getJSModule(RCTEventEmitter.class).receiveEvent(getId(), "state", event);


### PR DESCRIPTION
## Summary
<!-- You can remove the following line if there is no issue to close automatically. -->
- It closes #280.
<!-- Please summarize what this pull request does in short sentences. -->
- Change type of variables related to time to float type 
- Before this change, `seekTo` and `currentTime` works with integer second.
- It supports float seconds in the `seekTo` and `currentTime`.
- I checked that `seekTo` and `currentTime` works on both iOS and Android.

## Test/Review Plan
- Code Review
- Please test it works on the sample project.
