### PR TITLE
Fix a crash issue on Android "Fatal Exception: java.lang.IllegalStateException"

### DIFF
--- a/android/src/main/java/com/inprogress/reactnativeyoutube/VideoFragment.java
+++ b/android/src/main/java/com/inprogress/reactnativeyoutube/VideoFragment.java
@@ -10,13 +10,13 @@ public class VideoFragment extends YouTubePlayerFragment {
     public VideoFragment() {}
 
 
-    public void setYoutubeView(YouTubeView youTubeView) {
+    public void setYouTubeView(YouTubeView youTubeView) {
         mYouTubeView = youTubeView;
     }
 
     public static VideoFragment newInstance(YouTubeView youTubeView) {
         VideoFragment fragment = new VideoFragment();
-        fragment.setYoutubeView(youTubeView);
+        fragment.setYouTubeView(youTubeView);
         return fragment;
     }
 

--- a/android/src/main/java/com/inprogress/reactnativeyoutube/YouTubePlayerController.java
+++ b/android/src/main/java/com/inprogress/reactnativeyoutube/YouTubePlayerController.java
@@ -312,7 +312,12 @@ public class YouTubePlayerController implements
             handler.postDelayed(new Runnable() {
                 @Override
                 public void run() {
-                   mYouTubePlayer.play();
+                    try {
+                        mYouTubePlayer.play();
+                    } catch (IllegalStateException e) {
+                        mYouTubeView.initPlayer();
+                        mYouTubePlayer.play();
+                    }
                 }
             }, 1);
         }

--- a/android/src/main/java/com/inprogress/reactnativeyoutube/YouTubeView.java
+++ b/android/src/main/java/com/inprogress/reactnativeyoutube/YouTubeView.java
@@ -18,6 +18,7 @@ public class YouTubeView extends FrameLayout {
     private YouTubePlayerController mYouTubeController;
     private VideoFragment mVideoFragment;
     private boolean mHasSavedInstance = false;
+    private String mApiKey;
 
     public YouTubeView(ReactContext context) {
         super(context);
@@ -32,6 +33,7 @@ public class YouTubeView extends FrameLayout {
         inflate(getContext(), R.layout.youtube_layout, this);
         mVideoFragment = VideoFragment.newInstance(this);
         mYouTubeController = new YouTubePlayerController(this);
+        mApiKey = null;
     }
 
     @Nullable
@@ -153,12 +155,17 @@ public class YouTubeView extends FrameLayout {
         reactContext.getJSModule(RCTEventEmitter.class).receiveEvent(getId(), "fullscreen", event);
     }
 
-    public void setApiKey(String apiKey) {
+    public void initPlayer() {
         try {
-            mVideoFragment.initialize(apiKey, mYouTubeController);
+            mVideoFragment.initialize(mApiKey, mYouTubeController);
         } catch (Exception e) {
             receivedError(e.getMessage());
         }
+    }
+
+    public void setApiKey(String apiKey) {
+        mApiKey = apiKey;
+        initPlayer();
     }
 
     public void setVideoId(String str) {


### PR DESCRIPTION
Hi,

Our team have experience a crash issue reported by Crashlytics saying "_Fatal Exception. This YouTubePlayer has been released (**YouTubePlayerController.java:315**)_"

We are using latest commit [#1c2d9dc](https://github.com/inProgress-team/react-native-youtube.git#1c2d9dc) (at the time of writing) for our package.json.

I have tried to strengthen the code with the "try ... catch" block and
would like to submit a pull request for review.

Thanks!
