### PR TITLE
Fix build issue with RN0.59

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,25 +1,22 @@
-buildscript {
-    repositories {
-        jcenter()
-    }
-
-   dependencies {
-        classpath 'com.android.tools.build:gradle:1.1.3'
-    }
-}
-
 apply plugin: 'com.android.library'
 
+
+def DEFAULT_COMPILE_SDK_VERSION             = 23
+def DEFAULT_BUILD_TOOLS_VERSION             = "23.0.1"
+def DEFAULT_MIN_SDK_VERSION                 = 16
+def DEFAULT_TARGET_SDK_VERSION              = 22
+
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    compileSdkVersion rootProject.hasProperty('compileSdkVersion') ? rootProject.compileSdkVersion : DEFAULT_COMPILE_SDK_VERSION
+    buildToolsVersion rootProject.hasProperty('buildToolsVersion') ? rootProject.buildToolsVersion : DEFAULT_BUILD_TOOLS_VERSION
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 22
+        minSdkVersion rootProject.hasProperty('minSdkVersion') ? rootProject.minSdkVersion : DEFAULT_MIN_SDK_VERSION
+        targetSdkVersion rootProject.hasProperty('targetSdkVersion') ? rootProject.targetSdkVersion : DEFAULT_TARGET_SDK_VERSION
         versionCode 1
         versionName "1.0"
     }
+
     lintOptions {
         abortOnError false
     }
@@ -30,6 +27,6 @@ repositories {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.facebook.react:react-native:+'
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    implementation 'com.facebook.react:react-native:+'
 }


### PR DESCRIPTION
I was getting the following errors from Gradle when using this lib on a clean RN0.59 project:

![Screen Shot 2019-05-15 at 10 42 06](https://user-images.githubusercontent.com/1708445/57762420-c7108f00-76ff-11e9-8295-3c28904245f2.png)

This gradle-file resolve that, however, I know next nothing about gradle/java/android build process and have no idea if this affects backward-compatibility or other things. So please keep that in mind before merging :)